### PR TITLE
Fix update operations returning old documents

### DIFF
--- a/src/controllers/user.controllers.ts
+++ b/src/controllers/user.controllers.ts
@@ -4,9 +4,7 @@ import { UserServices } from '@services'
 import { AuthServices } from '@services'
 
 export default class UserControllers {
-  // TODO: TO FIX: data are being updated but the returned result is the old one
-  //? I think it's something related to the ORM, first I thought the bug is caused by PATCH HTTP methods
-  //? But event using POST the bug continue to appear. Note: all routes use ORM update
+  // Update handlers rely on ORM update methods. Ensure the new document is returned
   //!--------------
   static async updateFirstName(req: express.Request, res: express.Response) {
     const payload = await UserServices.updateFirstName(req.body.user.id, req.body.firstName)

--- a/src/models/refresh.dao.ts
+++ b/src/models/refresh.dao.ts
@@ -21,7 +21,7 @@ export default class DAORefresh {
     oldToken: string,
     newToken: AuthTypes.RefreshToken
   ): Promise<refreshModel.Refresh | null> {
-    return await refreshModel.default.findOneAndUpdate({ token: oldToken }, newToken)
+    return await refreshModel.default.findOneAndUpdate({ token: oldToken }, newToken, { new: true })
   }
 
   static async clearTokens(query: any): Promise<void> {

--- a/src/models/role.dao.ts
+++ b/src/models/role.dao.ts
@@ -18,6 +18,6 @@ export default class DAORole {
   }
 
   static async updateRoleById(roleId: string, data: any): Promise<roleModel.Role | null> {
-    return await roleModel.default.findByIdAndUpdate(roleId, data)
+    return await roleModel.default.findByIdAndUpdate(roleId, data, { new: true })
   }
 }

--- a/src/models/user.dao.ts
+++ b/src/models/user.dao.ts
@@ -14,11 +14,11 @@ export default class DAOUser {
   }
 
   static async updateUser(query: any, update: any): Promise<userModel.User | null> {
-    return await userModel.default.findOneAndUpdate(query, update)
+    return await userModel.default.findOneAndUpdate(query, update, { new: true })
   }
 
   static async updateUserById(userId: string, update: any): Promise<userModel.User | null> {
-    return await userModel.default.findByIdAndUpdate(userId, update)
+    return await userModel.default.findByIdAndUpdate(userId, update, { new: true })
   }
 
   static async deleteUser(email: string): Promise<string | null> {

--- a/src/services/user.services.ts
+++ b/src/services/user.services.ts
@@ -31,7 +31,7 @@ export default class UserServices {
   }
 
   static async updateLastName(userId: string, newLastName: string): Promise<userModel.User> {
-    const user = await DAOUser.updateUserById(userId, { firstName: newLastName })
+    const user = await DAOUser.updateUserById(userId, { lastName: newLastName })
     return user as userModel.User
   }
 


### PR DESCRIPTION
## Summary
- ensure mongoose update functions return new documents by default
- fix parameter for last name update
- clean up outdated TODO comments

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6841cf34d700832598cd247723e9d40a